### PR TITLE
Use recommended config for react-hooks

### DIFF
--- a/packages/eslint-config/rules/react/react-hooks.js
+++ b/packages/eslint-config/rules/react/react-hooks.js
@@ -1,11 +1,6 @@
 module.exports = {
   extends: ['plugin:react-hooks/recommended'],
   plugins: ['react-hooks'],
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
   rules: {
     // Enforce Rules of Hooks
     // https://github.com/facebook/react/blob/c11015ff4f610ac2924d1fc6d569a17657a404fd/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js

--- a/packages/eslint-config/rules/react/react-hooks.js
+++ b/packages/eslint-config/rules/react/react-hooks.js
@@ -1,4 +1,11 @@
 module.exports = {
+  extends: ['plugin:react-hooks/recommended'],
+  plugins: ['react-hooks'],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
   rules: {
     // Enforce Rules of Hooks
     // https://github.com/facebook/react/blob/c11015ff4f610ac2924d1fc6d569a17657a404fd/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js

--- a/packages/eslint-config/rules/react/react.js
+++ b/packages/eslint-config/rules/react/react.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['plugin:react/recommended', 'prettier/react'],
-  plugins: ['react', 'react-hooks'],
+  plugins: ['react'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,


### PR DESCRIPTION
Not sure if this is wanted, so PR is more like "why not" instead of "why".

The `parserOptions` object was copied for parity between other React configs. It might be redundant. 