### PR TITLE
fix: remove typescript-eslint forceSuggestionFixer option

### DIFF
--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -295,7 +295,6 @@ const tsPreset = {
           {
             ignoreConditionalTests: true,
             ignoreMixedLogicalExpressions: true,
-            forceSuggestionFixer: false,
           },
         ],
 


### PR DESCRIPTION
This option was recently removed from typescript-eslint (https://github.com/typescript-eslint/typescript-eslint/pull/5835) and it breaks `eslint` run when using the newest version

<img width="1335" alt="CleanShot 2022-10-26 at 11 31 17@2x" src="https://user-images.githubusercontent.com/1269121/198054393-990f6dd5-38ca-4358-a806-bdc5dcbea19f.png">
